### PR TITLE
feat(pql) Add basic parser to pql language

### DIFF
--- a/ats/pql/pql.py
+++ b/ats/pql/pql.py
@@ -65,16 +65,6 @@ def evaluate_query(text: str):
 
         return name
 
-    def match_variable_in_query_token(variables):
-        assert_token("VARIABLE_IN_QUERY_TOKEN")
-        nonlocal current_token
-        if current_token != variables[0] and current_token != variables[1]:
-            raise ValueError(
-                f"Token '{current_token}' is not a valid VARIABLE_IN_QUERY_TOKEN"
-            )
-
-        current_token = get_next_token()
-
     def match_design_entity_relationship():
         assert_token("DESIGN_ENTITY_RELATIONSHIP_TOKEN")
         nonlocal current_token

--- a/ats/pql/pql.py
+++ b/ats/pql/pql.py
@@ -1,0 +1,180 @@
+from ats.tokenizer import tokenize
+from ats.parser.utils import is_integer_token, is_name_token
+from ats.pql.utils import is_variable_type_token, is_program_design_entity_relationship_token, is_string_token
+
+
+def parse_query(text: str):
+    tokens = tokenize(text)
+    current_token = None
+    variables = []
+
+    def get_next_token():
+        if len(tokens) > 0:
+            return tokens.pop(0)
+
+        return None
+
+    def assert_token(expected_token: str):
+        nonlocal current_token
+        if current_token is None:
+            raise ValueError(f"Expected {expected_token}, got end of file")
+
+    def match_token(token: str):
+        assert_token(f"token '{token}'")
+        nonlocal current_token
+        if current_token != token:
+            raise ValueError(f"Expected token '{token}', got '{current_token}'")
+
+        current_token = get_next_token()
+
+    def match_variable_type_token():
+        assert_token("VARTYPE_TOKEN")
+        nonlocal current_token
+        var_type = current_token
+        print(is_variable_type_token(current_token))
+        print(current_token)
+        if not is_variable_type_token(current_token):
+            raise ValueError(f"Token '{current_token}' is not a valid VARIABLE_TYPE_TOKEN")
+
+        current_token = get_next_token()
+
+        return var_type
+    
+    def match_variable_is_in_list_token(variables):
+        assert_token("DECLARED_VARIABLE_TOKEN")
+        nonlocal current_token
+        if variables[current_token] is None:
+            raise ValueError(f"Token '{current_token}' is not a valid DECLARED_VARIABLE_TOKEN")
+
+        searchingVariable = current_token
+        current_token = get_next_token()
+
+        return searchingVariable
+
+    def match_name_token():
+        assert_token("NAME_TOKEN")
+        nonlocal current_token
+        if not is_name_token(current_token):
+            raise ValueError(f"Token '{current_token}' is not a valid NAME_TOKEN")
+
+        name = current_token
+        current_token = get_next_token()
+
+        return name
+
+    def match_variable_in_query_token(variables):
+        assert_token("VARIABLE_IN_QUERY_TOKEN")
+        nonlocal current_token
+        # w przyszłości jak zostanie dodane "and" do pql trzeba będzie to rozszerzyć o ilość zmiennych występujących w zapytaniu, 
+        # póki co są tylko 2 więc narazie to wystarczy
+        if current_token != variables[0] and current_token != variables[1]:
+            raise ValueError(f"Token '{current_token}' is not a valid VARIABLE_IN_QUERY_TOKEN")
+
+        current_token = get_next_token()
+
+
+    def match_design_entity_relationship():
+        assert_token("DESIGN_ENTITY_RELATIONSHIP_TOKEN")
+        nonlocal current_token
+        if not is_program_design_entity_relationship_token(current_token):
+            raise ValueError(f"Token '{current_token}' is not a valid NAME_TOKEN")
+
+        relationship = current_token
+        current_token = get_next_token()
+        if current_token == "*": 
+            relationship += "*"
+            current_token = get_next_token()
+
+        return relationship
+
+
+    def match_end_of_declaration_token():
+        assert_token("NAME_DECLARATION_TOKEN")
+        nonlocal current_token
+        if current_token != "," and current_token != ";":
+            raise ValueError(f"Token '{current_token}' is not a valid NAME_DECLARATION_TOKEN")
+
+        name = current_token
+        current_token = get_next_token()
+
+        return name
+
+    def match_parameter_token(variables):
+        assert_token("RELATIONSHIP_PARAMETER_TOKEN")
+        nonlocal current_token
+        if not is_string_token(current_token) and not is_integer_token(current_token) and variables[current_token] is None:
+            raise ValueError(f"Token '{current_token}' is not a valid RELATIONSHIP_PARAMETER_TOKEN")
+            
+        parameter = current_token
+        current_token = get_next_token()
+
+        return parameter
+
+    def process_pql_code():
+        nonlocal current_token
+        current_token = get_next_token()
+        variables = process_variable({})
+        process_operation(variables)       
+
+        return None
+
+    def process_operation(variables):
+        nonlocal current_token
+        while is_variable_type_token(current_token):
+            variables = process_variable(variables)
+
+        process_query(variables)
+
+        return None
+
+    def process_query(variables):
+        nonlocal current_token
+        match_token("Select")
+        searching_variable = match_variable_is_in_list_token(variables)
+        is_with = false
+
+        match_token("such")
+        match_token("that")
+        relationship = match_design_entity_relationship()
+        match_token("(")
+        first_parameter = match_parameter_token(variables)
+        match_token(",")
+        second_parameter = match_parameter_token(variables)
+        match_token(")")
+        
+        if current_token == "with": 
+            is_with = true
+            match_token("with")
+
+        match_variable_in_query_token([first_parameter, second_parameter])
+
+        match_token(".")
+        
+
+        print(variables)
+        print(searching_variable)
+        print(relationship)
+        print(first_parameter)
+        print(second_parameter)
+
+        return None
+
+
+    def process_variable(variables):
+        nonlocal current_token
+        var_type = match_variable_type_token()
+        variables = process_variable_name(var_type, variables)
+
+        return variables
+
+    def process_variable_name(var_type: str, variables):
+        name = match_name_token()
+        end_token = match_end_of_declaration_token()
+        variables[name] = var_type
+
+        if end_token == ",":
+            return process_variable_name(var_type, variables)
+
+        return variables
+
+    return process_pql_code()

--- a/ats/pql/pql.py
+++ b/ats/pql/pql.py
@@ -6,7 +6,6 @@ from ats.pql.utils import is_variable_type_token, is_program_design_entity_relat
 def parse_query(text: str):
     tokens = tokenize(text)
     current_token = None
-    variables = []
 
     def get_next_token():
         if len(tokens) > 0:

--- a/ats/pql/pql.py
+++ b/ats/pql/pql.py
@@ -130,7 +130,7 @@ def parse_query(text: str):
         nonlocal current_token
         match_token("Select")
         searching_variable = match_variable_is_in_list_token(variables)
-        is_with = false
+        # is_with = False
 
         match_token("such")
         match_token("that")
@@ -141,19 +141,26 @@ def parse_query(text: str):
         second_parameter = match_parameter_token(variables)
         match_token(")")
         
-        if current_token == "with": 
-            is_with = true
-            match_token("with")
+        ##With do ogarniecia w poniedzialek ale ogolnie bede sprawdzal bez matcha, bo match wywala bledy, dlatego po prostu sprawdze co jest nastepnego i 
+        #wg tego bede dalej postepowac albo to z with albo kolejny select, w nastepnych iteracjach and itp
+        # if current_token == "with": 
+        #     is_with = True
+        #     match_token("with")
 
-        match_variable_in_query_token([first_parameter, second_parameter])
-
-        match_token(".")
+        #To też do with sprawdzenie czy parametr przed kropką jest w zapytaniu
+        # match_variable_in_query_token([first_parameter, second_parameter])
+        # match_token(".")
         
 
+        print("Zmienne w mapie")
         print(variables)
+        print("Szukana wartosc")
         print(searching_variable)
+        print("Relacja w zapytaniu")
         print(relationship)
+        print("Pierwszy parametr")
         print(first_parameter)
+        print("Drugi parametr")
         print(second_parameter)
 
         return None

--- a/ats/pql/pql.py
+++ b/ats/pql/pql.py
@@ -34,8 +34,6 @@ def evaluate_query(text: str):
         assert_token("VARTYPE_TOKEN")
         nonlocal current_token
         var_type = current_token
-        # print(is_variable_type_token(current_token))
-        # print(current_token)
         if not is_variable_type_token(current_token):
             raise ValueError(
                 f"Token '{current_token}' is not a valid VARIABLE_TYPE_TOKEN"
@@ -48,10 +46,8 @@ def evaluate_query(text: str):
     def match_variable_is_in_list_token(variables):
         assert_token("DECLARED_VARIABLE_TOKEN")
         nonlocal current_token
-        if variables[current_token] is None:
-            raise ValueError(
-                f"Token '{current_token}' is not a valid DECLARED_VARIABLE_TOKEN"
-            )
+        if current_token not in variables:
+            raise ValueError(f"Token '{current_token}' is not declared")
 
         searchingVariable = current_token
         current_token = get_next_token()
@@ -72,8 +68,6 @@ def evaluate_query(text: str):
     def match_variable_in_query_token(variables):
         assert_token("VARIABLE_IN_QUERY_TOKEN")
         nonlocal current_token
-        # w przyszłości jak zostanie dodane "and" do pql trzeba będzie to rozszerzyć o ilość zmiennych występujących w zapytaniu,
-        # póki co są tylko 2 więc narazie to wystarczy
         if current_token != variables[0] and current_token != variables[1]:
             raise ValueError(
                 f"Token '{current_token}' is not a valid VARIABLE_IN_QUERY_TOKEN"

--- a/ats/pql/pql.py
+++ b/ats/pql/pql.py
@@ -126,11 +126,12 @@ def evaluate_query(text: str):
     def process_pql_code():
         nonlocal current_token
         current_token = get_next_token()
-        return process_operation([], {})
+        variables = process_variable({})
+        return process_operation([], variables)
 
     def process_operation(queries, variables):
         nonlocal current_token
-        while is_variable_type_token(current_token):
+        while current_token != "Select":
             variables = process_variable(variables)
 
         queries.append(process_query(variables))

--- a/ats/pql/utils.py
+++ b/ats/pql/utils.py
@@ -2,7 +2,7 @@ import re
 
 
 def is_variable_type_token(text: str):
-    return True if text == "stmt" or text == "assign" or text == "while" else False
+    return text in ["stmt", "assign", "while"]
 
 def is_program_design_entity_relationship_token(text: str):
     return text in ["Modifies", "Follows", "Parent"]

--- a/ats/pql/utils.py
+++ b/ats/pql/utils.py
@@ -8,4 +8,4 @@ def is_program_design_entity_relationship_token(text: str):
     return True if text == "Modifies" or text == "Follows" or text == "Parent" else False
 
 def is_string_token(text: str):
-    return bool(re.match(r'^".*"$', text))
+    return bool(re.match(r'^"[^"]*"$', text))

--- a/ats/pql/utils.py
+++ b/ats/pql/utils.py
@@ -1,0 +1,11 @@
+import re
+
+
+def is_variable_type_token(text: str):
+    return True if text == "stmt" or text == "assign" or text == "while" else False
+
+def is_program_design_entity_relationship_token(text: str):
+    return True if text == "Modifies" or text == "Follows" or text == "Parent" else False
+
+def is_string_token(text: str):
+    return bool(re.match(r'^".*"$', text))

--- a/ats/pql/utils.py
+++ b/ats/pql/utils.py
@@ -4,8 +4,10 @@ import re
 def is_variable_type_token(text: str):
     return text in ["stmt", "assign", "while"]
 
+
 def is_program_design_entity_relationship_token(text: str):
     return text in ["Modifies", "Follows", "Parent"]
+
 
 def is_string_token(text: str):
     return bool(re.match(r'^"[^"]*"$', text))

--- a/ats/pql/utils.py
+++ b/ats/pql/utils.py
@@ -6,7 +6,7 @@ def is_variable_type_token(text: str):
 
 
 def is_program_design_entity_relationship_token(text: str):
-    return text in ["Modifies", "Follows", "Parent"]
+    return text in ["Modifies", "Follows", "Parent", "Uses"]
 
 
 def is_string_token(text: str):

--- a/ats/pql/utils.py
+++ b/ats/pql/utils.py
@@ -5,7 +5,7 @@ def is_variable_type_token(text: str):
     return True if text == "stmt" or text == "assign" or text == "while" else False
 
 def is_program_design_entity_relationship_token(text: str):
-    return True if text == "Modifies" or text == "Follows" or text == "Parent" else False
+    return text in ["Modifies", "Follows", "Parent"]
 
 def is_string_token(text: str):
     return bool(re.match(r'^"[^"]*"$', text))

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import sys
 
 from ats.parser.parser import parse
-from ats.pql.pql import parse_query
+from ats.pql.pql import evaluate_query
 
 if __name__ == "__main__":
     sys.stdout.reconfigure(encoding="utf-8")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import sys
 
 from ats.parser.parser import parse
+from ats.pql.pql import parse_query
 
 if __name__ == "__main__":
     sys.stdout.reconfigure(encoding="utf-8")

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 import sys
 
 from ats.parser.parser import parse
-from ats.pql.pql import evaluate_query
 
 if __name__ == "__main__":
     sys.stdout.reconfigure(encoding="utf-8")

--- a/tests/pql/test_declarations.py
+++ b/tests/pql/test_declarations.py
@@ -20,11 +20,9 @@ def test_complex_stmt_declaration():
         """
     )
 
-    assert (
-        result[0]["variables"]["s1"] == "stmt"
-        and result[0]["variables"]["s2"] == "stmt"
-        and result[0]["variables"]["s3"] == "stmt"
-    )
+    assert result[0]["variables"]["s1"] == "stmt"
+    assert result[0]["variables"]["s2"] == "stmt"
+    assert result[0]["variables"]["s3"] == "stmt"
 
 
 def test_simple_assign_declaration():
@@ -44,11 +42,9 @@ def test_complex_assign_declaration():
         """
     )
 
-    assert (
-        result[0]["variables"]["a1"] == "assign"
-        and result[0]["variables"]["a2"] == "assign"
-        and result[0]["variables"]["a3"] == "assign"
-    )
+    assert result[0]["variables"]["a1"] == "assign"
+    assert result[0]["variables"]["a2"] == "assign"
+    assert result[0]["variables"]["a3"] == "assign"
 
 
 def test_simple_while_declaration():
@@ -68,11 +64,9 @@ def test_complex_while_declaration():
         """
     )
 
-    assert (
-        result[0]["variables"]["w1"] == "while"
-        and result[0]["variables"]["w2"] == "while"
-        and result[0]["variables"]["w3"] == "while"
-    )
+    assert result[0]["variables"]["w1"] == "while"
+    assert result[0]["variables"]["w2"] == "while"
+    assert result[0]["variables"]["w3"] == "while"
 
 
 def test_complex_stmt_declaration_short():
@@ -82,11 +76,9 @@ def test_complex_stmt_declaration_short():
         """
     )
 
-    assert (
-        result[0]["variables"]["s1"] == "stmt"
-        and result[0]["variables"]["s2"] == "stmt"
-        and result[0]["variables"]["s3"] == "stmt"
-    )
+    assert result[0]["variables"]["s1"] == "stmt"
+    assert result[0]["variables"]["s2"] == "stmt"
+    assert result[0]["variables"]["s3"] == "stmt"
 
 
 def test_complex_assign_declaration_short():
@@ -96,11 +88,9 @@ def test_complex_assign_declaration_short():
         """
     )
 
-    assert (
-        result[0]["variables"]["a1"] == "assign"
-        and result[0]["variables"]["a2"] == "assign"
-        and result[0]["variables"]["a3"] == "assign"
-    )
+    assert result[0]["variables"]["a1"] == "assign"
+    assert result[0]["variables"]["a2"] == "assign"
+    assert result[0]["variables"]["a3"] == "assign"
 
 
 def test_complex_while_declaration_short():
@@ -110,11 +100,9 @@ def test_complex_while_declaration_short():
         """
     )
 
-    assert (
-        result[0]["variables"]["w1"] == "while"
-        and result[0]["variables"]["w2"] == "while"
-        and result[0]["variables"]["w3"] == "while"
-    )
+    assert result[0]["variables"]["w1"] == "while"
+    assert result[0]["variables"]["w2"] == "while"
+    assert result[0]["variables"]["w3"] == "while"
 
 
 def test_complex_variuos_types_declaration():
@@ -124,21 +112,15 @@ def test_complex_variuos_types_declaration():
         """
     )
 
-    assert (
-        result[0]["variables"]["s1"] == "stmt"
-        and result[0]["variables"]["s2"] == "stmt"
-        and result[0]["variables"]["s3"] == "stmt"
-    )
-    assert (
-        result[0]["variables"]["a1"] == "assign"
-        and result[0]["variables"]["a2"] == "assign"
-        and result[0]["variables"]["a3"] == "assign"
-    )
-    assert (
-        result[0]["variables"]["w1"] == "while"
-        and result[0]["variables"]["w2"] == "while"
-        and result[0]["variables"]["w3"] == "while"
-    )
+    assert result[0]["variables"]["s1"] == "stmt"
+    assert result[0]["variables"]["s2"] == "stmt"
+    assert result[0]["variables"]["s3"] == "stmt"
+    assert result[0]["variables"]["a1"] == "assign"
+    assert result[0]["variables"]["a2"] == "assign"
+    assert result[0]["variables"]["a3"] == "assign"
+    assert result[0]["variables"]["w1"] == "while"
+    assert result[0]["variables"]["w2"] == "while"
+    assert result[0]["variables"]["w3"] == "while"
 
 
 def test_type_error_declaration():

--- a/tests/pql/test_declarations.py
+++ b/tests/pql/test_declarations.py
@@ -13,6 +13,17 @@ def test_simple_stmt_declaration():
     assert result[0]["variables"]["s1"] == "stmt"
 
 
+def test_not_valid_end_of_declaration():
+    with pytest.raises(
+        ValueError, match="Token '/' is not a valid NAME_DECLARATION_TOKEN"
+    ):
+        evaluate_query(
+            """ stmt s1; stmt s2/ stmt s3;
+                Select s1 such that Parent(s1, "x")
+            """
+        )
+
+
 def test_complex_stmt_declaration():
     result = evaluate_query(
         """ stmt s1; stmt s2; stmt s3;

--- a/tests/pql/test_declarations.py
+++ b/tests/pql/test_declarations.py
@@ -1,9 +1,181 @@
+import pytest
+
 from ats.pql.pql import evaluate_query
 
 
 def test_simple_stmt_declaration():
-    evaluate_query(
+    result = evaluate_query(
         """ stmt s1;
             Select s1 such that Parent(s1, "x")
         """
     )
+
+    assert result[0]["variables"]["s1"] == "stmt"
+
+
+def test_complex_stmt_declaration():
+    result = evaluate_query(
+        """ stmt s1; stmt s2; stmt s3;
+            Select s1 such that Parent(s1, "x")
+        """
+    )
+
+    assert (
+        result[0]["variables"]["s1"] == "stmt"
+        and result[0]["variables"]["s2"] == "stmt"
+        and result[0]["variables"]["s3"] == "stmt"
+    )
+
+
+def test_simple_assign_declaration():
+    result = evaluate_query(
+        """ assign a1;
+            Select a1 such that Parent(a1, "pen")
+        """
+    )
+
+    assert result[0]["variables"]["a1"] == "assign"
+
+
+def test_complex_assign_declaration():
+    result = evaluate_query(
+        """ assign a1; assign a2; assign a3;
+            Select a2 such that Parent(a2, "ls")
+        """
+    )
+
+    assert (
+        result[0]["variables"]["a1"] == "assign"
+        and result[0]["variables"]["a2"] == "assign"
+        and result[0]["variables"]["a3"] == "assign"
+    )
+
+
+def test_simple_while_declaration():
+    result = evaluate_query(
+        """ while w1;
+            Select w1 such that Parent(w1, "r2")
+        """
+    )
+
+    assert result[0]["variables"]["w1"] == "while"
+
+
+def test_complex_while_declaration():
+    result = evaluate_query(
+        """ while w1; while w2; while w3;
+            Select w3 such that Parent(w3, "iusearchbtw")
+        """
+    )
+
+    assert (
+        result[0]["variables"]["w1"] == "while"
+        and result[0]["variables"]["w2"] == "while"
+        and result[0]["variables"]["w3"] == "while"
+    )
+
+
+def test_complex_stmt_declaration_short():
+    result = evaluate_query(
+        """ stmt s1, s2, s3;
+            Select s1 such that Parent(s1, "x")
+        """
+    )
+
+    assert (
+        result[0]["variables"]["s1"] == "stmt"
+        and result[0]["variables"]["s2"] == "stmt"
+        and result[0]["variables"]["s3"] == "stmt"
+    )
+
+
+def test_complex_assign_declaration_short():
+    result = evaluate_query(
+        """ assign a1; assign a2; assign a3;
+            Select a2 such that Parent(a2, "ls")
+        """
+    )
+
+    assert (
+        result[0]["variables"]["a1"] == "assign"
+        and result[0]["variables"]["a2"] == "assign"
+        and result[0]["variables"]["a3"] == "assign"
+    )
+
+
+def test_complex_while_declaration_short():
+    result = evaluate_query(
+        """ while w1, w2, w3;
+            Select w3 such that Parent(w3, "iusearchbtw")
+        """
+    )
+
+    assert (
+        result[0]["variables"]["w1"] == "while"
+        and result[0]["variables"]["w2"] == "while"
+        and result[0]["variables"]["w3"] == "while"
+    )
+
+
+def test_complex_variuos_types_declaration():
+    result = evaluate_query(
+        """ while w1, w2, w3; stmt s1, s2, s3; assign a1, a2, a3;
+            Select w3 such that Parent(w3, "iusearchbtw")
+        """
+    )
+
+    assert (
+        result[0]["variables"]["s1"] == "stmt"
+        and result[0]["variables"]["s2"] == "stmt"
+        and result[0]["variables"]["s3"] == "stmt"
+    )
+    assert (
+        result[0]["variables"]["a1"] == "assign"
+        and result[0]["variables"]["a2"] == "assign"
+        and result[0]["variables"]["a3"] == "assign"
+    )
+    assert (
+        result[0]["variables"]["w1"] == "while"
+        and result[0]["variables"]["w2"] == "while"
+        and result[0]["variables"]["w3"] == "while"
+    )
+
+
+def test_type_error_declaration():
+    with pytest.raises(
+        ValueError, match="Token 'stmd' is not a valid VARIABLE_TYPE_TOKEN"
+    ):
+        evaluate_query(
+            """ stmd s1;
+                Select s1 such that Parent(s1, "x")
+            """
+        )
+
+
+def test_multiple_type_error_declaration():
+    with pytest.raises(
+        ValueError, match="Token 'asinge' is not a valid VARIABLE_TYPE_TOKEN"
+    ):
+        evaluate_query(
+            """ stmt s1; while w2; asinge a3;
+                Select s1 such that Parent(s1, "x")
+            """
+        )
+
+
+def test_varname_error_declaration():
+    with pytest.raises(ValueError, match="Token '31' is not a valid NAME_TOKEN"):
+        evaluate_query(
+            """ stmt 31;
+                Select s1 such that Parent(s1, "x")
+            """
+        )
+
+
+def test_multiple_varname_error_declaration():
+    with pytest.raises(ValueError, match="Token '35' is not a valid NAME_TOKEN"):
+        evaluate_query(
+            """ stmt s1, 35;
+                Select s1 such that Parent(s1, "x")
+            """
+        )

--- a/tests/pql/test_declarations.py
+++ b/tests/pql/test_declarations.py
@@ -1,0 +1,9 @@
+from ats.pql.pql import evaluate_query
+
+
+def test_simple_stmt_declaration():
+    evaluate_query(
+        """ stmt s1;
+            Select s1 such that Parent(s1, "x")
+        """
+    )

--- a/tests/pql/test_query.py
+++ b/tests/pql/test_query.py
@@ -1,0 +1,9 @@
+from ats.pql.pql import evaluate_query
+
+
+def test_simple_evaluator_query():
+    evaluate_query(
+        """ stmt s1;
+            Select s1 such that Parent(s1, "x")
+        """
+    )

--- a/tests/pql/test_query.py
+++ b/tests/pql/test_query.py
@@ -194,9 +194,12 @@ def test_multiply_with_query():
         """
     )
 
+    assert len(result[0]["with"]) == 2
     assert result[0]["with"][0]["left"] == "w3"
     assert result[0]["with"][0]["attr_left"] == "condition"
     assert result[0]["with"][0]["right"] == '"x"'
+    assert result[0]["with"][0]["attr_right"] is None
     assert result[0]["with"][1]["left"] == "s2"
     assert result[0]["with"][1]["attr_left"] == "attrName"
     assert result[0]["with"][1]["right"] == '"boligrafo"'
+    assert result[0]["with"][1]["attr_right"] is None

--- a/tests/pql/test_query.py
+++ b/tests/pql/test_query.py
@@ -170,7 +170,7 @@ def test_complex_query_evaluator():
     )
 
 
-def test_():
+def test_basic_with_query():
     result = evaluate_query(
         """
             while w3;
@@ -181,3 +181,20 @@ def test_():
     assert result[0]["with"][0]["left"] == "w3"
     assert result[0]["with"][0]["attr_left"] == "atrrName"
     assert result[0]["with"][0]["right"] == '"x"'
+
+
+def test_multiply_with_query():
+    result = evaluate_query(
+        """
+            while w3; stmt s2;
+            Select w3 such that Uses(20, w3) with w3.condition = "x"
+            with s2.attrName = "boligrafo"
+        """
+    )
+
+    assert result[0]["with"][0]["left"] == "w3"
+    assert result[0]["with"][0]["attr_left"] == "condition"
+    assert result[0]["with"][0]["right"] == '"x"'
+    assert result[0]["with"][1]["left"] == "s2"
+    assert result[0]["with"][1]["attr_left"] == "attrName"
+    assert result[0]["with"][1]["right"] == '"boligrafo"'

--- a/tests/pql/test_query.py
+++ b/tests/pql/test_query.py
@@ -195,7 +195,7 @@ def test_simply_with_left_query():
     assert result[0]["with"][0]["attr_right"] is None
 
 
-def test_simply_with_right_query():
+def test_simply_with_query():
     result = evaluate_query(
         """
             while w3;
@@ -250,3 +250,16 @@ def test_query_result():
     )
 
     assert result is not None
+
+
+def test_multiply_select_query():
+    evaluate_query(
+        """
+            while w3; stmt s2;
+            Select w3 such that Uses(20, w3) with w3.condition = "x"
+            with s2.attrName = "boligrafo"
+            assign a3;
+            Select w3 such that Uses(a3, w3) with w3.condition = "x"
+            with s2.attrName = "boligrafo"
+            """
+    )

--- a/tests/pql/test_query.py
+++ b/tests/pql/test_query.py
@@ -178,7 +178,7 @@ def test_basic_with_query():
         """
     )
 
-assert len(result[0]["with"]) == 1
+    assert len(result[0]["with"]) == 1
     assert result[0]["with"][0]["left"] == "w3"
     assert result[0]["with"][0]["attr_left"] == "atrrName"
     assert result[0]["with"][0]["right"] == '"x"'

--- a/tests/pql/test_query.py
+++ b/tests/pql/test_query.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ats.pql.pql import evaluate_query
 
 
@@ -7,3 +9,175 @@ def test_simple_evaluator_query():
             Select s1 such that Parent(s1, "x")
         """
     )
+
+
+def test_searching_variable():
+    result = evaluate_query(
+        """ stmt s1;
+            Select s1 such that Parent(s1, "x")
+        """
+    )
+
+    assert result[0]["searching_variable"] == "s1"
+
+
+def test_is_valid_searching_variable():
+    result = evaluate_query(
+        """ stmt s1;
+            Select s1 such that Parent(s1, "x")
+        """
+    )
+
+    assert result[0]["searching_variable"] == "s1"
+
+
+def test_not_valid_searching_variable():
+    with pytest.raises(ValueError, match="Token 's4' is not declared"):
+        evaluate_query(
+            """ stmt s1;
+                Select s4 such that Parent(s1, "x")
+           """
+        )
+
+
+def test_not_valid_select_statement():
+    with pytest.raises(
+        ValueError, match="Token 'Selekt' is not a valid VARIABLE_TYPE_TOKEN"
+    ):
+        evaluate_query(
+            """ stmt s1;
+                Selekt s1 such that Parent(s1, "x")
+           """
+        )
+
+
+def test_not_valid_such_statement():
+    with pytest.raises(ValueError, match="Expected token 'such', got 'sum'"):
+        evaluate_query(
+            """ stmt s1;
+                Select s1 sum that Parent(s1, "x")
+           """
+        )
+
+
+def test_not_valid_that_statement():
+    with pytest.raises(ValueError, match="Expected token 'that', got 'dat'"):
+        evaluate_query(
+            """ stmt s1;
+                Select s1 such dat Parent(s1, "x")
+           """
+        )
+
+
+def test_relation_parent_in_query():
+    result = evaluate_query(
+        """ stmt s1;
+            Select s1 such that Parent(s1, "x")
+           """
+    )
+
+    assert result[0]["relation"] == "Parent"
+
+
+def test_relation_parent_star_in_query():
+    result = evaluate_query(
+        """ stmt s1;
+            Select s1 such that Parent*(s1, "x")
+           """
+    )
+
+    assert result[0]["relation"] == "Parent*"
+
+
+def test_relation_follows_in_query():
+    result = evaluate_query(
+        """ assign a2;
+            Select a2 such that Follows(a2, "x")
+           """
+    )
+
+    assert result[0]["relation"] == "Follows"
+
+
+def test_relation_follows_star_in_query():
+    result = evaluate_query(
+        """ assign a2;
+            Select a2 such that Follows*(a2, "x")
+           """
+    )
+
+    assert result[0]["relation"] == "Follows*"
+
+
+def test_relation_modifies_in_query():
+    result = evaluate_query(
+        """ assign a2;
+            Select a2 such that Modifies(a2, "x")
+           """
+    )
+
+    assert result[0]["relation"] == "Modifies"
+
+
+def test_relation_uses_in_query():
+    result = evaluate_query(
+        """ while w3;
+            Select w3 such that Uses(w3, "x")
+           """
+    )
+
+    assert result[0]["relation"] == "Uses"
+
+
+def test_valid_parameters_with_string_in_relations():
+    result = evaluate_query(
+        """ while w3;
+            Select w3 such that Uses(w3, "x")
+           """
+    )
+
+    assert result[0]["parameters"][0] == "w3"
+    assert result[0]["parameters"][1] == '"x"'
+
+
+def test_valid_parameters_with_integer_in_relations():
+    result = evaluate_query(
+        """ while w3;
+            Select w3 such that Uses(20, w3)
+           """
+    )
+
+    assert result[0]["parameters"][0] == "20"
+    assert result[0]["parameters"][1] == "w3"
+
+
+def test_not_valid_parameters_in_relations():
+    with pytest.raises(ValueError, match="Variable 'xd1' is not declared"):
+        evaluate_query(
+            """
+            while w3;
+            Select w3 such that Uses(xd1, w3)
+            """
+        )
+
+
+def test_complex_query_evaluator():
+    evaluate_query(
+        """
+            while w3;
+            Select w3 such that Uses(20, w3) with w3.atrrName = "x"
+            """
+    )
+
+
+def test_():
+    result = evaluate_query(
+        """
+            while w3;
+            Select w3 such that Uses(20, w3) with w3.atrrName = "x"
+        """
+    )
+
+    assert result[0]["with"][0]["left"] == "w3"
+    assert result[0]["with"][0]["attr_left"] == "atrrName"
+    assert result[0]["with"][0]["right"] == '"x"'

--- a/tests/pql/test_query.py
+++ b/tests/pql/test_query.py
@@ -129,6 +129,16 @@ def test_relation_uses_in_query():
     assert result[0]["relation"] == "Uses"
 
 
+def test_not_valid_relation_in_query():
+    with pytest.raises(ValueError, match="Token 'Useless' is not a valid NAME_TOKEN"):
+        evaluate_query(
+            """
+            while w3;
+            Select w3 such that Useless(w3, "x")
+            """
+        )
+
+
 def test_valid_parameters_with_string_in_relations():
     result = evaluate_query(
         """ while w3;
@@ -170,7 +180,7 @@ def test_complex_query_evaluator():
     )
 
 
-def test_basic_with_query():
+def test_simply_with_left_query():
     result = evaluate_query(
         """
             while w3;
@@ -183,6 +193,21 @@ def test_basic_with_query():
     assert result[0]["with"][0]["attr_left"] == "atrrName"
     assert result[0]["with"][0]["right"] == '"x"'
     assert result[0]["with"][0]["attr_right"] is None
+
+
+def test_simply_with_right_query():
+    result = evaluate_query(
+        """
+            while w3;
+            Select w3 such that Uses(20, w3) with "x" = w3.atrrName
+        """
+    )
+
+    assert len(result[0]["with"]) == 1
+    assert result[0]["with"][0]["right"] == "w3"
+    assert result[0]["with"][0]["attr_right"] == "atrrName"
+    assert result[0]["with"][0]["left"] == '"x"'
+    assert result[0]["with"][0]["attr_left"] is None
 
 
 def test_multiply_with_query():
@@ -203,3 +228,25 @@ def test_multiply_with_query():
     assert result[0]["with"][1]["attr_left"] == "attrName"
     assert result[0]["with"][1]["right"] == '"boligrafo"'
     assert result[0]["with"][1]["attr_right"] is None
+
+
+def test_too_fast_end_of_query():
+    with pytest.raises(ValueError, match="Expected VARTYPE_TOKEN, got end of file"):
+        evaluate_query(
+            """
+
+            """
+        )
+
+
+def test_query_result():
+    result = evaluate_query(
+        """
+            while w3; stmt s2;
+            Select w3 such that Uses(20, w3) with w3.condition = "x"
+            with s2.attrName = "boligrafo"
+
+            """
+    )
+
+    assert result is not None

--- a/tests/pql/test_query.py
+++ b/tests/pql/test_query.py
@@ -182,6 +182,7 @@ assert len(result[0]["with"]) == 1
     assert result[0]["with"][0]["left"] == "w3"
     assert result[0]["with"][0]["attr_left"] == "atrrName"
     assert result[0]["with"][0]["right"] == '"x"'
+    assert result[0]["with"][0]["attr_right"] is None
 
 
 def test_multiply_with_query():

--- a/tests/pql/test_query.py
+++ b/tests/pql/test_query.py
@@ -178,6 +178,7 @@ def test_basic_with_query():
         """
     )
 
+assert len(result[0]["with"]) == 1
     assert result[0]["with"][0]["left"] == "w3"
     assert result[0]["with"][0]["attr_left"] == "atrrName"
     assert result[0]["with"][0]["right"] == '"x"'


### PR DESCRIPTION
Zrobiłem tutaj podstawowy parser do pql, który wykrywa deklaracje zmiennych, zapytanie select, szukaną zmienną w zapytaniu, rozpoznanie nazwy funkcji Follows, Parent(poki co tyle bo do testow nie bylo potrzeby wiekszych ilosci), with oraz nazwe zmiennej czy znajduje sie w zapytaniu i mozna ja dodac do warunku.

Do dodania:
 - dodac obsluge roznych atrybutow zmiennej do ```with nazwa_zmiennej.atrybut = cos```
 - zrobic to tak by sie zapetlalo, czyli by moglo nastepowac kilka zapytan po sobie i na przemian deklaracje zmiennych
 - wynik zwracany z fukncji z udostepnionego api Follows, Parent, Modifies itp. wyswietlic wedlug zmiennej nastpujacej po klauzuli ```Select```
 
 Dodaje drafta, by sprawdzić, czy idzie to w dobrym kierunku, w wykladach jest by zrobić query tree i w sumie nie jest to jakoś dokładnie opisane jak ma działać, dlatego póki co wyodrębniłem poszczególne elementy zapytania i przypisałem je do konkretnych zmiennych, które będzie można wykorzystać przy wyświetlaniu wyniku zapytania i analizy zwróconych danych z Follows, Parent itp.